### PR TITLE
Create diff-hunk-posframe recipe.

### DIFF
--- a/recipes/diff-hunk-posframe
+++ b/recipes/diff-hunk-posframe
@@ -1,0 +1,1 @@
+(diff-hunk-posframe :fetcher bitbucket :repo "inigoserna/diff-hunk-posframe.el")


### PR DESCRIPTION
Display diff hunk in a child frame.

### Brief summary of what the package does

Display diff hunk in a child frame.                                                                                                                                                                                                             
This package has a main function, diff-hunk-posframe. When executed opens a child frame showing the diff for the current hunk of code at point.                                                                                                                                                                                                      

Most of code has been taken from flyspell-posframe.el package and diff-hl-diff-goto-hunk function from diff-hl package.
It requires posframe >= 0.4.0 and diff-hl >= 1.8.0.

### Direct link to the package repository

Code is in https://bitbucket.org/inigoserna/diff-hunk-posframe.el/

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
